### PR TITLE
Fix: Prevent duplicate vertices in MeshClipper

### DIFF
--- a/Assets/Scripts/MeshClipper.cs
+++ b/Assets/Scripts/MeshClipper.cs
@@ -95,22 +95,22 @@ public static class MeshClipper
 
             if (insidePrev && insideCurr)
             {
-                if (outPoly.Count == 0 || (curr - outPoly[^1]).sqrMagnitude > 1e-9f)
+                if (ShouldAddVertex(curr, outPoly))
                     outPoly.Add(curr);
             }
             else if (insidePrev && !insideCurr)
             {
                 var intersection = Intersect(prev, curr, distPrev, distCurr);
-                if (outPoly.Count == 0 || (intersection - outPoly[^1]).sqrMagnitude > 1e-9f)
+                if (ShouldAddVertex(intersection, outPoly))
                     outPoly.Add(intersection);
             }
             else if (!insidePrev && insideCurr)
             {
                 var intersection = Intersect(prev, curr, distPrev, distCurr);
-                if (outPoly.Count == 0 || (intersection - outPoly[^1]).sqrMagnitude > 1e-9f)
+                if (ShouldAddVertex(intersection, outPoly))
                     outPoly.Add(intersection);
 
-                if (outPoly.Count == 0 || (curr - outPoly[^1]).sqrMagnitude > 1e-9f)
+                if (ShouldAddVertex(curr, outPoly))
                     outPoly.Add(curr);
             }
 
@@ -132,5 +132,10 @@ public static class MeshClipper
     {
         var t = distA / (distA - distB);
         return a + t * (b - a);
+    }
+    
+    private static bool ShouldAddVertex(Vector3 vertex, List<Vector3> polygon)
+    {
+        return polygon.Count == 0 || (vertex - polygon[^1]).sqrMagnitude > 1e-9f;
     }
 }

--- a/Assets/Scripts/MeshClipper.cs
+++ b/Assets/Scripts/MeshClipper.cs
@@ -95,16 +95,23 @@ public static class MeshClipper
 
             if (insidePrev && insideCurr)
             {
-                outPoly.Add(curr);
+                if (outPoly.Count == 0 || (curr - outPoly[^1]).sqrMagnitude > 1e-9f)
+                    outPoly.Add(curr);
             }
             else if (insidePrev && !insideCurr)
             {
-                outPoly.Add(Intersect(prev, curr, distPrev, distCurr));
+                var intersection = Intersect(prev, curr, distPrev, distCurr);
+                if (outPoly.Count == 0 || (intersection - outPoly[^1]).sqrMagnitude > 1e-9f)
+                    outPoly.Add(intersection);
             }
             else if (!insidePrev && insideCurr)
             {
-                outPoly.Add(Intersect(prev, curr, distPrev, distCurr));
-                outPoly.Add(curr);
+                var intersection = Intersect(prev, curr, distPrev, distCurr);
+                if (outPoly.Count == 0 || (intersection - outPoly[^1]).sqrMagnitude > 1e-9f)
+                    outPoly.Add(intersection);
+
+                if (outPoly.Count == 0 || (curr - outPoly[^1]).sqrMagnitude > 1e-9f)
+                    outPoly.Add(curr);
             }
 
             prev = curr;


### PR DESCRIPTION
The `MeshClipper.ClipAxis` method could generate duplicate vertices when a polygon vertex lay exactly on the clipping plane. This resulted in degenerate polygons in the output mesh.

This commit fixes the issue by adding a check to ensure that a vertex is only added to the output polygon if it is not a duplicate of the previously added vertex. A small tolerance is used to account for floating-point inaccuracies.